### PR TITLE
Remove verbosity from freshclam DB update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Action leverages our own [WP-CLI Vulnerability Scanner](https://github.com/
 
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
-| `vuln_api_provider` | True | - | The vulnerability API provider for the WordPress plugins and themes scanning. Supported values: `wordfence`, `patchstack` and `wpscan` |
+| `vuln_api_provider` | False | `wordfence` | The vulnerability API provider for the WordPress plugins and themes scanning. Supported values: `wordfence`, `patchstack` and `wpscan` |
 | `vuln_api_token` | False | - | The API token to authenticate against the vulnerability API provider. This input is optional if `vuln_api_provider` is set to `wordfence` |
 | `disable_vuln_scan` | False | `false` | Disable the WordPress plugins and themes vulnerability scanner |
 | `virus_scan_update` | False | `true` | Update the ClamAV definitions database before executing the virus scanner (recommended) |
@@ -30,7 +30,7 @@ This Action leverages our own [WP-CLI Vulnerability Scanner](https://github.com/
 
 # Examples
 
-## Install Composer dependencies before scanning
+## Basic example with Composer dependencies
 
 This example assumes that you have a `wp-content` based repository and uses [Patchstack](https://patchstack.com/) as the API provider.
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,8 @@ branding:
 inputs:
   vuln_api_provider:
     description: 'Vulnerability API provider'
-    required: true
+    required: false
+    default: 'wordfence'
   vuln_api_token:
     description: 'Token to authenticate with the vulnerability API provider'
     required: false

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -8,7 +8,7 @@ LABEL "com.github.actions.icon"="shield"
 LABEL "com.github.actions.color"="blue"
 
 LABEL maintainer="10upbot <10upbot+github@10up.com>"
-LABEL version="1.0.0"
+LABEL version="v1.0.1"
 LABEL repository="https://github.com/10up/wp-scanner-action"
 
 RUN apt-get update \


### PR DESCRIPTION
### Description of the Change
* Remove verbosity from `freshclam` DB update command
* Force trailing slash for `WP_CONTENT_DIR` variable
* Ensure `wp-config.php` file is deleted from `wordpress` dir in `setup_wordpress` function
* Separate vuln scanner into 2 functions, themes and plugins
* Separate vuln scanner setup into its own function
* Use `--porcelain` flag in vuln WPCLI command to avoid using `grep`
* Set the `vuln_api_provider` as not required and set its default value to `wordfence`
* Documentation updates