### PR TITLE
Bump PHP to 8.3

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim
 
-ARG PHP_VERSION=8.2
+ARG PHP_VERSION=8.3
 
 LABEL "com.github.actions.name"="WordPress Scanner Action"
 LABEL "com.github.actions.description"="Scan WordPress sites for plugins and themes vulnerabilities, PHP syntax and viruses"


### PR DESCRIPTION
### Description of the Change

Increases PHP to 8.3

### How to test the Change

With a repo whose `composer.lock` file specifies PHP 8.3, run this action. It should not fail.

### Changelog Entry

> Changed - Increased Docker PHP version to 8.3

### Credits
Props @benlk

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
